### PR TITLE
Updated netiam-errors to version 2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jsdom": "6.5.1",
     "lodash": "3.10.1",
     "mongoose": "4.1.9",
-    "netiam-errors": "1.10.1",
+    "netiam-errors": "2.0.0",
     "passport": "0.3.0",
     "passport-http": "0.3.0",
     "passport-http-bearer": "1.0.1",


### PR DESCRIPTION
:rocket:

netiam-errors just published version 2.0.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/netiam/errors/releases/tag/v2.0.0)

<a name"2.0.0"></a>
## 2.0.0 (2015-10-03)
#### Bug Fixes
- remove code parameter in subclass constructor definition ([bbec1ff4](https://github.com/netiam/errors/commit/bbec1ff4))
- use OS specific linefeed ([f5814c6b](https://github.com/netiam/errors/commit/f5814c6b))
- do not add code and type ([fe4fbb5c](https://github.com/netiam/errors/commit/fe4fbb5c))
#### Features
- add error codes (types) ([a5bafed1](https://github.com/netiam/errors/commit/a5bafed1))
- add toString method for errors ([cb4a8a20](https://github.com/netiam/errors/commit/cb4a8a20))
- errors are now subclasses of Error ([1218c68a](https://github.com/netiam/errors/commit/1218c68a))
#### Breaking Changes
- will break any usage with code and type in error
  initialization.
  
  ([fe4fbb5c](https://github.com/netiam/errors/commit/fe4fbb5c))
- this requires an update to all errors created by helper
  functions.
  
  ([1218c68a](https://github.com/netiam/errors/commit/1218c68a))

---

The new version differs by 15 commits (ahead by 15, behind by 0).
- [642b84d](https://github.com/netiam/errors/commit/642b84d52834c93b83ecbe1d9a2b8c14298c8e82): chore: release v2 channel
- [156123e](https://github.com/netiam/errors/commit/156123e934a0d8374d9701f81c1a927cec421e20): chore: change entry point to lib/index.js
- [a5bafed](https://github.com/netiam/errors/commit/a5bafed1c6f112a78ee8abe226a81495d1357137): feat: add error codes (types)
- [1225a3a](https://github.com/netiam/errors/commit/1225a3af66e27d79dcb6ee833974ee52040bf197): chore: release as `next`
- [4c420a3](https://github.com/netiam/errors/commit/4c420a3791244c5bb2029461260ad592a0f86e81): chore(CI): test on more platforms
- [2c8eeab](https://github.com/netiam/errors/commit/2c8eeab22bdf0c01bfc7dc2cc1e07a338d8dd5eb): test: add status code tests for all classes subclassing HTTPError
- [bbec1ff](https://github.com/netiam/errors/commit/bbec1ff458e91a8e68230dd2765ad1aa37161a67): fix: remove code parameter in subclass constructor definition
- [bb198a0](https://github.com/netiam/errors/commit/bb198a04804b73c12f8d4fb61f847253d390555d): chore: remove unused util import
- [f5814c6](https://github.com/netiam/errors/commit/f5814c6b91cd67b2db7cd6dcdeb766f082a46dfb): fix: use OS specific linefeed
- [cb4a8a2](https://github.com/netiam/errors/commit/cb4a8a2077d7756b201518355ad1af0747fc754f): feat: add toString method for errors
- [fe4fbb5](https://github.com/netiam/errors/commit/fe4fbb5caea41f34674468d1d31eb0761b165c79): fix: do not add code and type
- [ce6c1a4](https://github.com/netiam/errors/commit/ce6c1a4e23d2be7f95a704f81dedca721657b904): chore: subclassing from es6-error
- [1218c68](https://github.com/netiam/errors/commit/1218c68adfc72a46a0542f761faf170b68f52173): feat: errors are now subclasses of Error
- [dbb71bf](https://github.com/netiam/errors/commit/dbb71bf3f1e0512f67ae44c809bc17310d14e9f1): refactor: use ES2015 class construct to extend Error
- [8787283](https://github.com/netiam/errors/commit/87872838d50a043d7904c64c61ed380a19a0d7e5): docs: update errors table

See the [full diff](https://github.com/netiam/errors/compare/ae06a33b4e502b9398f0c6799d219f38443ded2f...642b84d52834c93b83ecbe1d9a2b8c14298c8e82).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
