### PR TITLE
Updated netiam-errors to version 2.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "jsdom": "6.5.1",
     "lodash": "3.10.1",
     "mongoose": "4.1.9",
-    "netiam-errors": "1.10.1",
+    "netiam-errors": "2.1.2",
     "passport": "0.3.0",
     "passport-http": "0.3.0",
     "passport-http-bearer": "1.0.1",


### PR DESCRIPTION
:rocket:

netiam-errors just published version 2.1.2, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

[GitHub Release](https://github.com/netiam/errors/releases/tag/v2.1.2)

<a name"2.1.2"></a>
### 2.1.2 (2015-10-03)
#### Bug Fixes
- just build for Node 4.x ([0dad77cc](https://github.com/netiam/errors/commit/0dad77cc))

---

The new version differs by 21 commits (ahead by 21, behind by 0).
- [0dad77c](https://github.com/netiam/errors/commit/0dad77cc2a81791dccfeadea8a1da48f02d31899): fix: just build for Node 4.x
- [d9ce84f](https://github.com/netiam/errors/commit/d9ce84f77cd18d6343fdbe4ef2b9172b6c7a2db9): fix: remove debug dep and trigger fresh release (sha sum issue)
- [22dcbc8](https://github.com/netiam/errors/commit/22dcbc8158599a60ec2eb2a9be343c95b4f9b501): Merge branch 'master' of github.com:netiam/errors
- [e3dbc99](https://github.com/netiam/errors/commit/e3dbc9950fa2aa8108e297a2900336db0c6ab3ac): feat: add authentication error
- [bf00a43](https://github.com/netiam/errors/commit/bf00a4317194cdac0db0a217d845ec9353133e02): Merge pull request #1 from netiam/greenkeeper-pin
- [9e38b94](https://github.com/netiam/errors/commit/9e38b94d05a729b415a5c0841a783071fa9ef218): chore(package): pin dependencies
- [642b84d](https://github.com/netiam/errors/commit/642b84d52834c93b83ecbe1d9a2b8c14298c8e82): chore: release v2 channel
- [156123e](https://github.com/netiam/errors/commit/156123e934a0d8374d9701f81c1a927cec421e20): chore: change entry point to lib/index.js
- [a5bafed](https://github.com/netiam/errors/commit/a5bafed1c6f112a78ee8abe226a81495d1357137): feat: add error codes (types)
- [1225a3a](https://github.com/netiam/errors/commit/1225a3af66e27d79dcb6ee833974ee52040bf197): chore: release as `next`
- [4c420a3](https://github.com/netiam/errors/commit/4c420a3791244c5bb2029461260ad592a0f86e81): chore(CI): test on more platforms
- [2c8eeab](https://github.com/netiam/errors/commit/2c8eeab22bdf0c01bfc7dc2cc1e07a338d8dd5eb): test: add status code tests for all classes subclassing HTTPError
- [bbec1ff](https://github.com/netiam/errors/commit/bbec1ff458e91a8e68230dd2765ad1aa37161a67): fix: remove code parameter in subclass constructor definition
- [bb198a0](https://github.com/netiam/errors/commit/bb198a04804b73c12f8d4fb61f847253d390555d): chore: remove unused util import
- [f5814c6](https://github.com/netiam/errors/commit/f5814c6b91cd67b2db7cd6dcdeb766f082a46dfb): fix: use OS specific linefeed

There are 21 commits in total. See the [full diff](https://github.com/netiam/errors/compare/ae06a33b4e502b9398f0c6799d219f38443ded2f...0dad77cc2a81791dccfeadea8a1da48f02d31899).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
