### PR TITLE
Updated validator to version 4.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "semantic-release": "4.3.5",
     "should": "7.1.0",
     "supertest": "1.1.0",
-    "validator": "4.0.6"
+    "validator": "4.1.0"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
:rocket:

validator just published version 4.1.0, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 15 commits (ahead by 15, behind by 0).
- [a5d3874](https://github.com/chriso/validator.js/commit/a5d38744c24efdf2c4b87189c2a55da4108a8149): 4.1.0
- [e696bc4](https://github.com/chriso/validator.js/commit/e696bc4bc4d44f4d8c6b2068d5ac20a5ed8d42f9): Update the min version
- [c23448e](https://github.com/chriso/validator.js/commit/c23448e1b42e9a50e34bc0fd7eac37eae1236129): Update the changelog
- [1813359](https://github.com/chriso/validator.js/commit/1813359fedfd565bad920a77a5edb430de361b45): Merge pull request #438 from chriso/chriso/node-4-support
- [37c7e72](https://github.com/chriso/validator.js/commit/37c7e722e0790f4488bc84685b58dd1ce8c7a0f4): Make a note in the README about dev requirements
- [eecb88f](https://github.com/chriso/validator.js/commit/eecb88fd00ca23e4acfd8c667456521eb82a95eb): Merge pull request #431 from ravestack/suchchange
- [eddbd0f](https://github.com/chriso/validator.js/commit/eddbd0f952626357176c4904849c81eecfad3fd4): change test to always have a valid date regardless of timezone, remove extraneous comment
- [ae32dfc](https://github.com/chriso/validator.js/commit/ae32dfc5fe19786518b935aa03241bf63c36ed5b): remove string check
- [2a6b4bd](https://github.com/chriso/validator.js/commit/2a6b4bd0160ab020e0be09a77260a6bfc1688462): add RFC 2822 tests, enforce double digits in matching
- [fecf7c7](https://github.com/chriso/validator.js/commit/fecf7c739e1df6b7d8ea67b61aa3c27208d2c032): Run tests with node 4 and 4.1
- [3070fb7](https://github.com/chriso/validator.js/commit/3070fb7eb52050a643545d64ba9868cea81bf2ab): Use the vm module instead of contextify
- [88bf49a](https://github.com/chriso/validator.js/commit/88bf49a8709fe2876e5acd2a54ecf4a4dbcd207d): misspelling
- [4beed24](https://github.com/chriso/validator.js/commit/4beed242b28fdc30d6556d723007f67c979c6bc0): add ISO 8601 tests
- [ff4d907](https://github.com/chriso/validator.js/commit/ff4d907df7a79ed209babd02d1254659fc0a08c9): Leap year and general date validation for isDate().
- [fc03288](https://github.com/chriso/validator.js/commit/fc03288cde9f3edd5eef2018c72262ba1153d06e): Update the changelog to reflect the current release

See the [full diff](https://github.com/chriso/validator.js/compare/827e916b7835c813131c24131eef1c07a6682e30...a5d38744c24efdf2c4b87189c2a55da4108a8149).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
