### PR TITLE
Updated mongoose to version 4.1.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "debug": "2.2.0",
     "jsdom": "6.5.1",
     "lodash": "3.10.1",
-    "mongoose": "4.1.9",
+    "mongoose": "4.1.10",
     "netiam-errors": "1.10.1",
     "passport": "0.3.0",
     "passport-http": "0.3.0",


### PR DESCRIPTION
:rocket:

mongoose just published version 4.1.10, so that’s now up to date in your `package.json`.

Check that it doesn’t break your code and release the new version of your software safe in the knowledge that it will stay in this working state.

---

The new version differs by 14 commits (ahead by 14, behind by 0).
- [43e3852](https://github.com/Automattic/mongoose/commit/43e3852e762a848b9daa9b80813b1771a0005887): Merge branch 'master' of github.com:Automattic/mongoose
- [74bdcf1](https://github.com/Automattic/mongoose/commit/74bdcf13e25303e576d19d630760279333464eb1): release 4.1.10
- [07b5fbf](https://github.com/Automattic/mongoose/commit/07b5fbfb32eab1a46da0f2cd6d2951a60e5bd7ec): Merge pull request #3433 from zoyaH/updated-virtuals-doc
- [c0df34e](https://github.com/Automattic/mongoose/commit/c0df34e07f44ad8b82594ac52a2fe43ba90a4e44): docs; mongodb compatibility matrix (Fix #3427)
- [389c8d0](https://github.com/Automattic/mongoose/commit/389c8d01576ced32f5cbe5e3001b008c83946ab1): docs; clean up findAndModify helper docs (#3422)
- [202b822](https://github.com/Automattic/mongoose/commit/202b8220ba80d335675a1779e1042960db010679): updated do for 2.7.x i.e virtuals fields should be display on client side.
- [0b0a2c1](https://github.com/Automattic/mongoose/commit/0b0a2c15e726501a98ccc5343a2181535936a0cd): docs; fix up Model.save() API docs (Fix #3420)
- [6aa34a5](https://github.com/Automattic/mongoose/commit/6aa34a51c99a7b804acead20c716a9e90976774d): Merge branch 'master' of github.com:Automattic/mongoose
- [7898851](https://github.com/Automattic/mongoose/commit/7898851e36aa244ed06a69df7f7bb0095449d608): docs; clarify remove hook (Fix #3388)
- [b640cc4](https://github.com/Automattic/mongoose/commit/b640cc49ff40a7430edb8e42c0b418d851102e0f): Update release-items.md
- [fff256c](https://github.com/Automattic/mongoose/commit/fff256c368ee6818d384d4988ead2889444e4cdc): set pre-release version
- [cf8c8da](https://github.com/Automattic/mongoose/commit/cf8c8da503f3d946b87a700a695c7da395870304): fix; defaults with just _id projected (Fix #3407)
- [d4d5717](https://github.com/Automattic/mongoose/commit/d4d57176848bcaaae20d466273f124355c0d262f): fix; no infinite loop on corrupt array (Fix #3405)
- [98e8e10](https://github.com/Automattic/mongoose/commit/98e8e1067d7f85b518b423599178d8c38d93d556): docs; get rid of -e that breaks docs build

See the [full diff](https://github.com/Automattic/mongoose/compare/eea56d8e460284927d4fd529bcf41ec762c01d57...43e3852e762a848b9daa9b80813b1771a0005887).

---

This pull request was created by [greenkeeper.io](http://greenkeeper.io/).
It keeps your software, up to date, all the time.

<sub>
Tired of seeing this sponsor message? Upgrade to the supporter plan!
You'll also get your pull requests faster :zap:
</sub>
